### PR TITLE
Prevent unbounded memory growth

### DIFF
--- a/AlbionDataAvalonia/Network/Services/NetworkListenerService.cs
+++ b/AlbionDataAvalonia/Network/Services/NetworkListenerService.cs
@@ -20,19 +20,20 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace AlbionDataAvalonia.Network.Services
 {
     public class NetworkListenerService : IDisposable
     {
-        private static readonly object deviceCLeanLock = new object();
-        private static readonly object listenLock = new object();
         private const string MacOSCapturePermissionSetupScriptName = "setup-capture-permissions.sh";
         private const string MacOSCapturePermissionLaunchDaemonPath =
             "/Library/LaunchDaemons/com.albionfreemarket.afmdataclient.chmodbpf.plist";
         private const string MacOSLegacyCapturePermissionScheduleKey = "<key>StartInterval</key>";
         private readonly HashSet<string> _unknownServerIps = new HashSet<string>();
+        private readonly object _lifecycleStateLock = new object();
+        private readonly SemaphoreSlim _lifecycleGate = new SemaphoreSlim(1, 1);
 
         private readonly Uploader _uploader;
         private readonly AFMUploader _afmUploader;
@@ -51,12 +52,12 @@ namespace AlbionDataAvalonia.Network.Services
         private readonly MobsService _mobsService;
         private readonly LegendaryItemTrackerService _legendaryTracker;
 
-        private bool hasCleanedUpDevices = false;
-        private bool hasFinishedStartingDevices = false;
-        private bool isListening = false;
-
-        private IPhotonReceiver? receiver;
-        private CaptureDeviceList? devices;
+        private CancellationTokenSource? _lifecycleCancellation;
+        private CaptureSession? _activeSession;
+        private long _lifecycleGeneration;
+        private bool _listeningRequested;
+        private bool _isPowerSuspended;
+        private bool _disposed;
 
         public event EventHandler? MacOSCapturePermissionSetupRequiredChanged;
         public bool IsMacOSCapturePermissionSetupRequired { get; private set; }
@@ -92,22 +93,84 @@ namespace AlbionDataAvalonia.Network.Services
                 && HasLegacyMacOSCapturePermissionSetup();
         }
 
-        public async Task StartNetworkListeningAsync()
+        public Task StartNetworkListeningAsync()
         {
-            lock (listenLock)
+            return RequestStartAsync(forceRestart: false);
+        }
+
+        private Task RequestStartAsync(bool forceRestart)
+        {
+            LifecycleRequest request;
+            CancellationTokenSource? previousCancellation;
+
+            lock (_lifecycleStateLock)
             {
-                if (isListening)
+                if (_disposed)
                 {
-                    Log.Information("Network listening is already active.");
-                    return;
+                    Log.Debug("Ignoring network listener start because the service is disposed.");
+                    return Task.CompletedTask;
                 }
-                isListening = true;
+
+                if (_isPowerSuspended)
+                {
+                    Log.Debug("Ignoring network listener start while the system is suspended.");
+                    return Task.CompletedTask;
+                }
+
+                if (_listeningRequested && !forceRestart)
+                {
+                    Log.Information("Network listening is already active or starting.");
+                    return Task.CompletedTask;
+                }
+
+                _listeningRequested = true;
+                request = CreateLifecycleRequestLocked();
+                previousCancellation = ReplaceLifecycleCancellationLocked(request.Cancellation);
             }
+
+            CancelLifecycleRequest(previousCancellation);
+            return ApplyStartRequestAsync(request, forceRestart);
+        }
+
+        private async Task ApplyStartRequestAsync(LifecycleRequest request, bool forceRestart)
+        {
+            CaptureSession? pendingSession = null;
+            var acquiredGate = false;
+            var startSucceeded = false;
+
             try
             {
+                await _lifecycleGate.WaitAsync(request.Token).ConfigureAwait(false);
+                acquiredGate = true;
+
+                if (!IsCurrentRequest(request, listeningRequested: true))
+                {
+                    return;
+                }
+
+                if (forceRestart)
+                {
+                    var previousSession = Interlocked.Exchange(ref _activeSession, null);
+                    TerminateSession(previousSession);
+                }
+                else if (Volatile.Read(ref _activeSession) is not null)
+                {
+                    startSucceeded = true;
+                    return;
+                }
+
                 //AWAIT SOME SECONDS FOR NETWORK STUFF TO BE READY
                 Log.Information($"Waiting {_settingsManager.AppSettings.NetworkDevicesStartDelaySecs} seconds for network drivers to be ready");
-                await Task.Delay(_settingsManager.AppSettings.NetworkDevicesStartDelaySecs * 1000);
+                await Task.Delay(
+                        TimeSpan.FromSeconds(_settingsManager.AppSettings.NetworkDevicesStartDelaySecs),
+                        request.Token)
+                    .ConfigureAwait(false);
+
+                request.Token.ThrowIfCancellationRequested();
+                if (!IsCurrentRequest(request, listeningRequested: true))
+                {
+                    return;
+                }
 
                 if (NpCapInstallationChecker.IsNpCapInstalled() == false)
                 {
@@ -201,9 +264,9 @@ namespace AlbionDataAvalonia.Network.Services
                 builder.AddHandler(new DebugRequestProbeRequestHandler());
 #endif
 
-                receiver = builder.Build();
+                var localReceiver = builder.Build();
 
-                if (receiver == null)
+                if (localReceiver == null)
                 {
                     Log.Error("Failed to create network receiver");
                     return;
@@ -211,22 +274,29 @@ namespace AlbionDataAvalonia.Network.Services
 
                 Log.Debug("Starting network device listening");
 
-                devices = CaptureDeviceList.New();
-                if (!devices.Any())
+                var discoveredDevices = CaptureDeviceList.New();
+                if (!discoveredDevices.Any())
                 {
                     Log.Error("No network capture devices were found.");
-                    isListening = false;
                     return;
                 }
 
+                pendingSession = new CaptureSession(localReceiver, this);
                 var openedDeviceCount = 0;
                 var failedDeviceCount = 0;
                 var sawPermissionDenied = false;
-                foreach (var device in devices)
+                foreach (var device in discoveredDevices)
                 {
-                    var result = await Task.Run(() => TryStartDeviceCapture(device, filter));
+                    request.Token.ThrowIfCancellationRequested();
+
+                    var registration = new CaptureDeviceRegistration(
+                        device,
+                        pendingSession.PacketHandler);
+                    var result = await Task.Run(() => TryStartDeviceCapture(registration, filter))
+                        .ConfigureAwait(false);
                     if (result.Opened)
                     {
+                        pendingSession.Devices.Add(registration);
                         openedDeviceCount++;
                     }
                     else
@@ -238,9 +308,6 @@ namespace AlbionDataAvalonia.Network.Services
 
                 if (openedDeviceCount == 0)
                 {
-                    hasFinishedStartingDevices = false;
-                    isListening = false;
-                    receiver = null;
                     LogNoCaptureDevicesOpened(failedDeviceCount, sawPermissionDenied);
                     return;
                 }
@@ -253,9 +320,22 @@ namespace AlbionDataAvalonia.Network.Services
                         failedDeviceCount);
                 }
 
+                request.Token.ThrowIfCancellationRequested();
                 SetMacOSCapturePermissionSetupRequired(false);
+                if (!TryPublishSession(request, pendingSession, out var replacedSession))
+                {
+                    return;
+                }
+
+                pendingSession = null;
+                TerminateSession(replacedSession);
+
                 Log.Information("Listening to Albion network packages!");
-                hasFinishedStartingDevices = true;
+                startSucceeded = true;
+            }
+            catch (OperationCanceledException) when (request.Token.IsCancellationRequested)
+            {
+                Log.Debug("Network listener start was superseded by a newer lifecycle request.");
             }
             catch (Exception ex)
             {
@@ -270,18 +350,31 @@ namespace AlbionDataAvalonia.Network.Services
                     SetMacOSCapturePermissionSetupRequired(false);
                     Log.Error(ex, "Error starting network listening");
                 }
+            }
+            finally
+            {
+                TerminateSession(pendingSession);
 
-                isListening = false;
+                if (acquiredGate)
+                {
+                    _lifecycleGate.Release();
+                }
+
+                CompleteLifecycleRequest(request, failedStart: !startSucceeded);
             }
         }
 
-        private CaptureDeviceOpenResult TryStartDeviceCapture(ILiveDevice device, string filter)
+        private CaptureDeviceOpenResult TryStartDeviceCapture(
+            CaptureDeviceRegistration registration,
+            string filter)
         {
+            var device = registration.Device;
+
             try
             {
-                Log.Debug("Opening network device: {Device}", GetDeviceDisplayName(device));
+                Log.Debug("Opening network device: {Device}", registration.DisplayName);
 
-                device.OnPacketArrival += new PacketArrivalEventHandler(PacketHandler);
+                device.OnPacketArrival += registration.PacketHandler;
                 device.Open(new DeviceConfiguration
                 {
                     Mode = DeviceModes.None,
@@ -290,22 +383,19 @@ namespace AlbionDataAvalonia.Network.Services
                 device.Filter = filter;
                 device.StartCapture();
 
-                Log.Debug("Opened network device: {Device} with filter: {Filter}", GetDeviceDisplayName(device), filter);
+                Log.Debug(
+                    "Opened network device: {Device} with filter: {Filter}",
+                    registration.DisplayName,
+                    filter);
                 return new CaptureDeviceOpenResult(true, false);
             }
             catch (Exception ex)
             {
-                device.OnPacketArrival -= PacketHandler;
-
-                try
-                {
-                    device.Close();
-                }
-                catch
-                {
-                }
-
-                Log.Warning(ex, "Error initializing network device {Device}.", GetDeviceDisplayName(device));
+                TerminateDeviceCapture(registration);
+                Log.Warning(
+                    ex,
+                    "Error initializing network device {Device}.",
+                    registration.DisplayName);
                 return new CaptureDeviceOpenResult(false, IsPacketCapturePermissionError(ex));
             }
         }
@@ -492,52 +582,52 @@ namespace AlbionDataAvalonia.Network.Services
                 : device.Description;
         }
 
-        private void PacketHandler(object? sender, PacketCapture e)
+        private void PacketHandler(CaptureSession session, object? sender, PacketCapture e)
         {
-            if (receiver == null)
+            if (!session.IsReady || !ReferenceEquals(Volatile.Read(ref _activeSession), session))
             {
-                Log.Error("Receiver is null");
                 return;
             }
-            if (!hasFinishedStartingDevices)
+
+            lock (session.ProcessingLock)
             {
-                Log.Debug("Not all devices have finished starting yet");
-                return;
+                if (!session.IsReady || !ReferenceEquals(Volatile.Read(ref _activeSession), session))
+                {
+                    return;
+                }
+
+                ProcessPacket(session, e);
             }
+        }
+
+        private void ProcessPacket(CaptureSession session, PacketCapture e)
+        {
             try
             {
-                _playerState.LastPacketTime = DateTime.UtcNow;
-
                 UdpPacket packet = Packet.ParsePacket(e.GetPacket().LinkLayerType, e.GetPacket().Data).Extract<UdpPacket>();
                 if (packet != null)
                 {
-                    if (!hasCleanedUpDevices && devices != null)
+                    var selectedDevice = Interlocked.CompareExchange(
+                        ref session.SelectedDevice,
+                        e.Device,
+                        null);
+                    if (selectedDevice is not null && !ReferenceEquals(selectedDevice, e.Device))
                     {
-                        lock (deviceCLeanLock)
+                        return;
+                    }
+
+                    if (selectedDevice is null)
+                    {
+                        foreach (var registration in session.Devices)
                         {
-                            if (!hasCleanedUpDevices && devices != null)
+                            if (!ReferenceEquals(registration.Device, e.Device))
                             {
-                                foreach (var device in devices)
-                                {
-                                    if (device != e.Device)
-                                    {
-                                        Task.Run(() =>
-                                        {
-                                            try
-                                            {
-                                                TerminateDeviceCapture(device);
-                                            }
-                                            catch (Exception ex)
-                                            {
-                                                Log.Debug("Error closing device {Device}: {Message}", device.Name, ex.Message);
-                                            }
-                                        });
-                                    }
-                                }
-                                hasCleanedUpDevices = true;
+                                _ = Task.Run(() => TerminateDeviceCapture(registration));
                             }
                         }
                     }
+
+                    _playerState.LastPacketTime = DateTime.UtcNow;
 
                     var srcIp = (packet.ParentPacket as IPPacket)?.SourceAddress?.ToString();
 
@@ -556,7 +646,13 @@ namespace AlbionDataAvalonia.Network.Services
                     {
                         Log.Warning("Received packet from unknown IP {Ip} — could not determine Albion server. Known unknown IPs so far: {Ips}", srcIp, string.Join(", ", _unknownServerIps));
                     }
-                    var packetStatus = receiver.ReceivePacket(packet.PayloadData);
+
+                    if (!ReferenceEquals(Volatile.Read(ref _activeSession), session))
+                    {
+                        return;
+                    }
+
+                    var packetStatus = session.Receiver.ReceivePacket(packet.PayloadData);
                     if (packetStatus == PacketStatus.Encrypted)
                     {
                         _playerState.HasEncryptedData = true;
@@ -581,69 +677,199 @@ namespace AlbionDataAvalonia.Network.Services
                     addr.GetAddressBytes() is var b && b.Length == 4 && b[1] >= 16 && b[1] <= 31);
         }
 
-        private void TerminateDeviceCapture(ILiveDevice device)
+        private void TerminateDeviceCapture(CaptureDeviceRegistration registration)
         {
-            if (device != null)
+            if (Interlocked.Exchange(ref registration.IsTerminated, 1) != 0)
             {
-                Log.Debug("Closing network device: {Device}", device.Description);
+                registration.TerminationCompleted.Task.GetAwaiter().GetResult();
+                return;
+            }
+
+            var device = registration.Device;
+
+            try
+            {
+                Log.Debug("Closing network device: {Device}", registration.DisplayName);
+
                 try
                 {
-                    device.StopCapture();
-                    device.Close();
-                    device.OnPacketArrival -= PacketHandler;
+                    device.OnPacketArrival -= registration.PacketHandler;
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Error closing device {Device}", device.Description);
+                    Log.Warning(
+                        ex,
+                        "Error unsubscribing from network device {Device}.",
+                        registration.DisplayName);
                 }
+
+                try
+                {
+                    device.StopCapture();
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug(
+                        ex,
+                        "Error stopping network device {Device}.",
+                        registration.DisplayName);
+                }
+
+                try
+                {
+                    device.Close();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(
+                        ex,
+                        "Error closing network device {Device}.",
+                        registration.DisplayName);
+                }
+
+                try
+                {
+                    (device as IDisposable)?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(
+                        ex,
+                        "Error disposing network device {Device}.",
+                        registration.DisplayName);
+                }
+            }
+            finally
+            {
+                registration.TerminationCompleted.TrySetResult(true);
             }
         }
 
-        private void TerminateAllDeviceCaptures()
+        private void TerminateSession(CaptureSession? session)
         {
-            if (devices is not null)
+            if (session is null)
             {
-                foreach (var device in devices)
+                return;
+            }
+
+            if (Interlocked.Exchange(ref session.IsTerminated, 1) != 0)
+            {
+                session.TerminationCompleted.Task.GetAwaiter().GetResult();
+                return;
+            }
+
+            try
+            {
+                session.IsReady = false;
+
+                lock (session.ProcessingLock)
+                {
+                }
+
+                foreach (var registration in session.Devices)
                 {
                     try
                     {
-                        TerminateDeviceCapture(device);
+                        TerminateDeviceCapture(registration);
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Error terminating device capture for {Device}", device.Description);
+                        Log.Error(
+                            ex,
+                            "Unexpected error terminating network device {Device}.",
+                            registration.DisplayName);
                     }
                 }
+            }
+            finally
+            {
+                session.TerminationCompleted.TrySetResult(true);
             }
         }
 
         public void StopNetworkListening()
         {
-            lock (listenLock)
+            RequestStopAsync(markPowerSuspended: false, disposeService: false)
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        private Task RequestStopAsync(bool markPowerSuspended, bool disposeService)
+        {
+            LifecycleRequest request;
+            CancellationTokenSource? previousCancellation;
+
+            lock (_lifecycleStateLock)
             {
-                if (!isListening)
+                if (_disposed)
+                {
+                    return Task.CompletedTask;
+                }
+
+                if (disposeService)
+                {
+                    _disposed = true;
+                }
+
+                if (markPowerSuspended || disposeService)
+                {
+                    _isPowerSuspended = true;
+                }
+
+                if (!_listeningRequested
+                    && Volatile.Read(ref _activeSession) is null
+                    && _lifecycleCancellation is null
+                    && !disposeService)
                 {
                     Log.Information("Network listening is already stopped.");
+                    return Task.CompletedTask;
+                }
+
+                _listeningRequested = false;
+                request = CreateLifecycleRequestLocked();
+                previousCancellation = ReplaceLifecycleCancellationLocked(request.Cancellation);
+            }
+
+            CancelLifecycleRequest(previousCancellation);
+            return ApplyStopRequestAsync(request);
+        }
+
+        private async Task ApplyStopRequestAsync(LifecycleRequest request)
+        {
+            var acquiredGate = false;
+
+            try
+            {
+                await _lifecycleGate.WaitAsync(request.Token).ConfigureAwait(false);
+                acquiredGate = true;
+
+                if (!IsCurrentRequest(request, listeningRequested: false))
+                {
                     return;
                 }
-                isListening = false;
+
+                Log.Information("Stopping network listening...");
+                var session = Interlocked.Exchange(ref _activeSession, null);
+                TerminateSession(session);
+                Log.Information("Network listening stopped successfully.");
             }
-            Log.Information("Stopping network listening...");
+            catch (OperationCanceledException) when (request.Token.IsCancellationRequested)
+            {
+                Log.Debug("Network listener stop was superseded by a newer lifecycle request.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error stopping network listening");
+            }
+            finally
+            {
+                if (acquiredGate)
+                {
+                    _lifecycleGate.Release();
+                }
 
-            // Stop and close all capture devices
-            TerminateAllDeviceCaptures();
-
-            // Reset the receiver
-            receiver = null;
-
-            // Reset the devices list
-            devices = null;
-
-            // Reset flags
-            hasCleanedUpDevices = false;
-            hasFinishedStartingDevices = false;
-
-            Log.Information("Network listening stopped successfully.");
+                CompleteLifecycleRequest(request, failedStart: false);
+            }
         }
 
         private void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
@@ -656,11 +882,13 @@ namespace AlbionDataAvalonia.Network.Services
                     {
                         case PowerModes.Suspend:
                             Log.Information("System is entering sleep/hibernate mode. Stopping network listening.");
-                            StopNetworkListening();
+                            RequestStopAsync(markPowerSuspended: true, disposeService: false)
+                                .GetAwaiter()
+                                .GetResult();
                             break;
                         case PowerModes.Resume:
                             Log.Information("System is resuming from sleep/hibernate. Starting network listening.");
-                            Task.Run(StartNetworkListeningAsync);
+                            _ = RequestResumeAsync();
                             break;
                     }
                 }
@@ -673,20 +901,183 @@ namespace AlbionDataAvalonia.Network.Services
 
         private void RestartNetworkListener()
         {
-            StopNetworkListening();
-            Task.Run(StartNetworkListeningAsync);
+            _ = RequestStartAsync(forceRestart: true);
+        }
+
+        private Task RequestResumeAsync()
+        {
+            lock (_lifecycleStateLock)
+            {
+                if (_disposed)
+                {
+                    return Task.CompletedTask;
+                }
+
+                _isPowerSuspended = false;
+            }
+
+            return RequestStartAsync(forceRestart: true);
         }
 
         public void Dispose()
         {
-            StopNetworkListening();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 SystemEvents.PowerModeChanged -= SystemEvents_PowerModeChanged;
             }
+
             _idleService.OnDetectedIdle -= RestartNetworkListener;
+
+            RequestStopAsync(markPowerSuspended: true, disposeService: true)
+                .GetAwaiter()
+                .GetResult();
+
             Log.Information("Disposed {type}!", nameof(NetworkListenerService));
         }
+
+        private LifecycleRequest CreateLifecycleRequestLocked()
+        {
+            var cancellation = new CancellationTokenSource();
+            return new LifecycleRequest(
+                ++_lifecycleGeneration,
+                cancellation,
+                cancellation.Token);
+        }
+
+        private CancellationTokenSource? ReplaceLifecycleCancellationLocked(
+            CancellationTokenSource cancellation)
+        {
+            var previousCancellation = _lifecycleCancellation;
+            _lifecycleCancellation = cancellation;
+            return previousCancellation;
+        }
+
+        private static void CancelLifecycleRequest(CancellationTokenSource? cancellation)
+        {
+            if (cancellation is null)
+            {
+                return;
+            }
+
+            try
+            {
+                cancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            finally
+            {
+                cancellation.Dispose();
+            }
+        }
+
+        private bool IsCurrentRequest(LifecycleRequest request, bool listeningRequested)
+        {
+            lock (_lifecycleStateLock)
+            {
+                return _lifecycleGeneration == request.Generation
+                    && _listeningRequested == listeningRequested
+                    && (!_disposed || !listeningRequested);
+            }
+        }
+
+        private bool TryPublishSession(
+            LifecycleRequest request,
+            CaptureSession session,
+            out CaptureSession? replacedSession)
+        {
+            lock (_lifecycleStateLock)
+            {
+                if (_lifecycleGeneration != request.Generation
+                    || !_listeningRequested
+                    || _disposed)
+                {
+                    replacedSession = null;
+                    return false;
+                }
+
+                session.IsReady = true;
+                replacedSession = Interlocked.Exchange(ref _activeSession, session);
+                return true;
+            }
+        }
+
+        private void CompleteLifecycleRequest(LifecycleRequest request, bool failedStart)
+        {
+            var disposeCancellation = false;
+
+            lock (_lifecycleStateLock)
+            {
+                if (_lifecycleGeneration == request.Generation && failedStart)
+                {
+                    _listeningRequested = false;
+                }
+
+                if (ReferenceEquals(_lifecycleCancellation, request.Cancellation))
+                {
+                    _lifecycleCancellation = null;
+                    disposeCancellation = true;
+                }
+            }
+
+            if (disposeCancellation)
+            {
+                request.Cancellation.Dispose();
+            }
+        }
+
+        private sealed class CaptureSession
+        {
+            private int _isReady;
+
+            public CaptureSession(
+                IPhotonReceiver receiver,
+                NetworkListenerService listener)
+            {
+                Receiver = receiver;
+                PacketHandler = (sender, packet) => listener.PacketHandler(this, sender, packet);
+            }
+
+            public IPhotonReceiver Receiver { get; }
+            public PacketArrivalEventHandler PacketHandler { get; }
+            public List<CaptureDeviceRegistration> Devices { get; } = new List<CaptureDeviceRegistration>();
+            public TaskCompletionSource<bool> TerminationCompleted { get; } =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public object ProcessingLock { get; } = new object();
+            public object? SelectedDevice;
+            public int IsTerminated;
+
+            public bool IsReady
+            {
+                get => Volatile.Read(ref _isReady) != 0;
+                set => Volatile.Write(ref _isReady, value ? 1 : 0);
+            }
+        }
+
+        private sealed class CaptureDeviceRegistration
+        {
+            public CaptureDeviceRegistration(
+                ILiveDevice device,
+                PacketArrivalEventHandler packetHandler)
+            {
+                Device = device;
+                PacketHandler = packetHandler;
+                DisplayName = GetDeviceDisplayName(device);
+            }
+
+            public ILiveDevice Device { get; }
+            public PacketArrivalEventHandler PacketHandler { get; }
+            public string DisplayName { get; }
+            public TaskCompletionSource<bool> TerminationCompleted { get; } =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            public int IsTerminated;
+        }
+
+        private readonly record struct LifecycleRequest(
+            long Generation,
+            CancellationTokenSource Cancellation,
+            CancellationToken Token);
 
         private readonly record struct CaptureDeviceOpenResult(bool Opened, bool PermissionDenied);
     }

--- a/AlbionDataAvalonia/ViewModels/CombatViewModel.cs
+++ b/AlbionDataAvalonia/ViewModels/CombatViewModel.cs
@@ -21,6 +21,8 @@ namespace AlbionDataAvalonia.ViewModels;
 
 public partial class CombatViewModel : ViewModelBase, IDisposable
 {
+    private static readonly TimeSpan SnapshotRefreshInterval = TimeSpan.FromMilliseconds(200);
+
     private static readonly TimeSpan ChartRefreshInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan ActiveSummaryRefreshInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan InactiveFameSummaryRefreshInterval = TimeSpan.FromSeconds(5);
@@ -40,6 +42,7 @@ public partial class CombatViewModel : ViewModelBase, IDisposable
 
     private readonly CombatTrackerService? combatTracker;
     private readonly SettingsManager? settingsManager;
+    private readonly LatestUiValueDispatcher<CombatTrackerSnapshot> snapshotDispatcher;
     private DispatcherTimer? summaryRefreshTimer;
     private IDisposable? pendingChartRefreshRegistration;
     private CombatTrackerSnapshot currentSnapshot;
@@ -278,6 +281,9 @@ public partial class CombatViewModel : ViewModelBase, IDisposable
 
     public CombatViewModel()
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<CombatTrackerSnapshot>(
+            ApplySnapshot,
+            SnapshotRefreshInterval);
         currentSnapshot = CombatTrackerSnapshot.Empty();
         isCombatTrackerDisabled = false;
         selectedChartWindow = InitializeChartWindowOptions();
@@ -288,6 +294,9 @@ public partial class CombatViewModel : ViewModelBase, IDisposable
 
     public CombatViewModel(CombatTrackerService combatTracker, SettingsManager settingsManager)
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<CombatTrackerSnapshot>(
+            ApplySnapshot,
+            SnapshotRefreshInterval);
         this.combatTracker = combatTracker;
         this.settingsManager = settingsManager;
         isCombatTrackerDisabled = settingsManager.UserSettings.DisableCombatTracker;
@@ -395,7 +404,7 @@ public partial class CombatViewModel : ViewModelBase, IDisposable
 
     private void OnSnapshotChanged(CombatTrackerSnapshot snapshot)
     {
-        Dispatcher.UIThread.Post(() => ApplySnapshot(snapshot));
+        snapshotDispatcher.Post(snapshot);
     }
 
     private void OnUserSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -2122,6 +2131,8 @@ public partial class CombatViewModel : ViewModelBase, IDisposable
         {
             combatTracker.SnapshotChanged -= OnSnapshotChanged;
         }
+
+        snapshotDispatcher.Dispose();
 
         if (settingsManager is not null)
         {

--- a/AlbionDataAvalonia/ViewModels/GatheringViewModel.cs
+++ b/AlbionDataAvalonia/ViewModels/GatheringViewModel.cs
@@ -24,12 +24,15 @@ namespace AlbionDataAvalonia.ViewModels;
 
 public partial class GatheringViewModel : ViewModelBase, IDisposable
 {
+    private static readonly TimeSpan SnapshotRefreshInterval = TimeSpan.FromMilliseconds(200);
+
     private readonly GatheringTrackerService? gatheringTracker;
     private readonly GatheringSessionPersistenceService? sessionPersistence;
     private readonly SettingsManager? settingsManager;
     private readonly ItemImageService? itemImageService;
     private readonly CsvExportService? csvExportService;
     private readonly PortfolioUploadService? portfolioUploadService;
+    private readonly LatestUiValueDispatcher<GatheringTrackerSnapshot> snapshotDispatcher;
     private const int ShareCardItemSlots = 20;
     private const string PreparingPortfolioImportStatus = "Preparing gathering session for Portfolio...";
     private DispatcherTimer? elapsedTimer;
@@ -122,6 +125,9 @@ public partial class GatheringViewModel : ViewModelBase, IDisposable
 
     public GatheringViewModel()
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<GatheringTrackerSnapshot>(
+            ApplySnapshot,
+            SnapshotRefreshInterval);
     }
 
     public GatheringViewModel(
@@ -132,6 +138,9 @@ public partial class GatheringViewModel : ViewModelBase, IDisposable
         CsvExportService csvExportService,
         PortfolioUploadService portfolioUploadService)
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<GatheringTrackerSnapshot>(
+            ApplySnapshot,
+            SnapshotRefreshInterval);
         this.gatheringTracker = gatheringTracker;
         this.sessionPersistence = sessionPersistence;
         this.settingsManager = settingsManager;
@@ -544,7 +553,7 @@ public partial class GatheringViewModel : ViewModelBase, IDisposable
 
     private void OnSnapshotChanged(GatheringTrackerSnapshot snapshot)
     {
-        Dispatcher.UIThread.Post(() => ApplySnapshot(snapshot));
+        snapshotDispatcher.Post(snapshot);
     }
 
     private void OnCompletedSessionsChanged()
@@ -876,6 +885,8 @@ public partial class GatheringViewModel : ViewModelBase, IDisposable
         {
             gatheringTracker.SnapshotChanged -= OnSnapshotChanged;
         }
+
+        snapshotDispatcher.Dispose();
 
         if (sessionPersistence is not null)
         {

--- a/AlbionDataAvalonia/ViewModels/LatestUiValueDispatcher.cs
+++ b/AlbionDataAvalonia/ViewModels/LatestUiValueDispatcher.cs
@@ -1,0 +1,103 @@
+using Avalonia.Threading;
+using System;
+
+namespace AlbionDataAvalonia.ViewModels;
+
+internal sealed class LatestUiValueDispatcher<T> : IDisposable
+    where T : class
+{
+    private readonly object sync = new();
+    private readonly Action<T> applyValue;
+    private readonly TimeSpan minimumInterval;
+    private IDisposable? pendingDrainRegistration;
+    private T? pendingValue;
+    private bool isScheduled;
+    private bool isDisposed;
+
+    public LatestUiValueDispatcher(Action<T> applyValue, TimeSpan minimumInterval = default)
+    {
+        this.applyValue = applyValue;
+        this.minimumInterval = minimumInterval;
+    }
+
+    public void Post(T value)
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+            {
+                return;
+            }
+
+            pendingValue = value;
+            if (isScheduled)
+            {
+                return;
+            }
+
+            isScheduled = true;
+        }
+
+        Dispatcher.UIThread.Post(ScheduleDrain);
+    }
+
+    private void ScheduleDrain()
+    {
+        lock (sync)
+        {
+            if (isDisposed)
+            {
+                pendingValue = null;
+                isScheduled = false;
+                return;
+            }
+
+            if (minimumInterval > TimeSpan.Zero)
+            {
+                pendingDrainRegistration = DispatcherTimer.RunOnce(Drain, minimumInterval);
+                return;
+            }
+        }
+
+        Drain();
+    }
+
+    private void Drain()
+    {
+        T? value;
+        lock (sync)
+        {
+            pendingDrainRegistration = null;
+            if (isDisposed)
+            {
+                pendingValue = null;
+                isScheduled = false;
+                return;
+            }
+
+            value = pendingValue;
+            pendingValue = null;
+            isScheduled = false;
+        }
+
+        if (value is not null)
+        {
+            applyValue(value);
+        }
+    }
+
+    public void Dispose()
+    {
+        IDisposable? drainRegistration;
+        lock (sync)
+        {
+            isDisposed = true;
+            pendingValue = null;
+            isScheduled = false;
+            drainRegistration = pendingDrainRegistration;
+            pendingDrainRegistration = null;
+        }
+
+        drainRegistration?.Dispose();
+    }
+}

--- a/AlbionDataAvalonia/ViewModels/LogsViewModel.cs
+++ b/AlbionDataAvalonia/ViewModels/LogsViewModel.cs
@@ -11,9 +11,15 @@ using System.Linq;
 
 namespace AlbionDataAvalonia.ViewModels
 {
-    public partial class LogsViewModel : ViewModelBase
+    public partial class LogsViewModel : ViewModelBase, IDisposable
     {
+        private const int MaxIncrementalLogBatchCount = 100;
         private readonly TimeSpan _filterDebounceInterval = TimeSpan.FromMilliseconds(250);
+
+        private readonly record struct PendingLogEvent(
+            LogEventWrapper LogEvent,
+            LogEventWrapper? RemovedBufferedEvent);
+
         public sealed class AmountShownOption
         {
             public int Value { get; }
@@ -34,9 +40,13 @@ namespace AlbionDataAvalonia.ViewModels
         private readonly ListSink _listSink;
         private readonly SettingsManager _settingsManager;
         private readonly List<LogEventWrapper> _allEventsNewestFirst = new();
+        private readonly List<PendingLogEvent> _pendingLogEvents = new();
         private readonly object _sync = new();
         private IDisposable? _pendingFilterRefreshRegistration;
         private string _appliedFilterText = string.Empty;
+        private bool _logDispatchScheduled;
+        private bool _pendingLogEventsRequireRebuild;
+        private volatile bool _isDisposed;
         private static readonly IReadOnlyList<AmountShownOption> _amountShownOptions =
         [
             new AmountShownOption(100, "100"),
@@ -116,20 +126,90 @@ namespace AlbionDataAvalonia.ViewModels
         private void OnLogEventReceived(LogEventWrapper logEventWrapper)
         {
             LogEventWrapper? removedBufferedEvent = null;
+            var shouldScheduleDispatch = false;
             lock (_sync)
             {
+                if (_isDisposed)
+                {
+                    return;
+                }
+
                 _allEventsNewestFirst.Insert(0, logEventWrapper);
                 if (_allEventsNewestFirst.Count > ListSink.MemoryRetentionLimit)
                 {
                     removedBufferedEvent = _allEventsNewestFirst[^1];
                     _allEventsNewestFirst.RemoveAt(_allEventsNewestFirst.Count - 1);
                 }
+
+                if (!_pendingLogEventsRequireRebuild)
+                {
+                    if (_pendingLogEvents.Count < MaxIncrementalLogBatchCount)
+                    {
+                        _pendingLogEvents.Add(new PendingLogEvent(logEventWrapper, removedBufferedEvent));
+                    }
+                    else
+                    {
+                        _pendingLogEvents.Clear();
+                        _pendingLogEventsRequireRebuild = true;
+                    }
+                }
+
+                if (!_logDispatchScheduled)
+                {
+                    _logDispatchScheduled = true;
+                    shouldScheduleDispatch = true;
+                }
             }
 
-            Dispatcher.UIThread.Post(() =>
+            if (shouldScheduleDispatch)
             {
-                ApplyIncomingEvent(logEventWrapper, removedBufferedEvent);
-            });
+                Dispatcher.UIThread.Post(DrainPendingLogEvents);
+            }
+        }
+
+        private void DrainPendingLogEvents()
+        {
+            List<PendingLogEvent>? pendingEvents;
+            bool rebuildVisibleEvents;
+            lock (_sync)
+            {
+                if (_isDisposed)
+                {
+                    _pendingLogEvents.Clear();
+                    _pendingLogEventsRequireRebuild = false;
+                    _logDispatchScheduled = false;
+                    return;
+                }
+
+                rebuildVisibleEvents = _pendingLogEventsRequireRebuild;
+                pendingEvents = rebuildVisibleEvents
+                    ? null
+                    : new List<PendingLogEvent>(_pendingLogEvents);
+                _pendingLogEvents.Clear();
+                _pendingLogEventsRequireRebuild = false;
+                _logDispatchScheduled = false;
+            }
+
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (rebuildVisibleEvents)
+            {
+                RebuildVisibleEvents();
+                return;
+            }
+
+            if (pendingEvents is null)
+            {
+                return;
+            }
+
+            foreach (var pendingEvent in pendingEvents)
+            {
+                ApplyIncomingEvent(pendingEvent.LogEvent, pendingEvent.RemovedBufferedEvent);
+            }
         }
 
         private void OnUserSettingsPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -138,6 +218,11 @@ namespace AlbionDataAvalonia.ViewModels
             {
                 Dispatcher.UIThread.Post(() =>
                 {
+                    if (_isDisposed)
+                    {
+                        return;
+                    }
+
                     OnPropertyChanged(nameof(SelectedLogVerbosity));
                     RebuildVisibleEvents();
                 });
@@ -148,6 +233,11 @@ namespace AlbionDataAvalonia.ViewModels
             {
                 Dispatcher.UIThread.Post(() =>
                 {
+                    if (_isDisposed)
+                    {
+                        return;
+                    }
+
                     OnPropertyChanged(nameof(SelectedAmountShown));
                     RebuildVisibleEvents();
                 });
@@ -163,8 +253,15 @@ namespace AlbionDataAvalonia.ViewModels
                     .Where(PassesActiveFilters)
                     .Take(GetVisibleLimit())
                     .ToList();
+                _pendingLogEvents.Clear();
+                _pendingLogEventsRequireRebuild = false;
             }
 
+            ReplaceVisibleEvents(visibleEvents);
+        }
+
+        private void ReplaceVisibleEvents(IEnumerable<LogEventWrapper> visibleEvents)
+        {
             Events.Clear();
             foreach (var logEvent in visibleEvents)
             {
@@ -257,6 +354,11 @@ namespace AlbionDataAvalonia.ViewModels
 
         private void ScheduleFilterEvents()
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+
             if (!Dispatcher.UIThread.CheckAccess())
             {
                 Dispatcher.UIThread.Post(ScheduleFilterEvents);
@@ -267,6 +369,11 @@ namespace AlbionDataAvalonia.ViewModels
             _pendingFilterRefreshRegistration = DispatcherTimer.RunOnce(() =>
             {
                 _pendingFilterRefreshRegistration = null;
+                if (_isDisposed)
+                {
+                    return;
+                }
+
                 _appliedFilterText = FilterText;
                 RebuildVisibleEvents();
             }, _filterDebounceInterval);
@@ -282,6 +389,22 @@ namespace AlbionDataAvalonia.ViewModels
         {
             // Keep logs search aligned with the existing mails/trades space-insensitive matching.
             return (value ?? string.Empty).Replace(" ", string.Empty);
+        }
+
+        public void Dispose()
+        {
+            _listSink.CollectionChanged -= OnLogEventReceived;
+            _settingsManager.UserSettings.PropertyChanged -= OnUserSettingsPropertyChanged;
+
+            lock (_sync)
+            {
+                _isDisposed = true;
+                _pendingLogEvents.Clear();
+                _pendingLogEventsRequireRebuild = false;
+                _logDispatchScheduled = false;
+            }
+
+            CancelPendingFilterRefresh();
         }
     }
 }

--- a/AlbionDataAvalonia/ViewModels/LootViewModel.cs
+++ b/AlbionDataAvalonia/ViewModels/LootViewModel.cs
@@ -21,11 +21,10 @@ public partial class LootViewModel : ViewModelBase, IDisposable
 
     private readonly LootTrackerService? lootTracker;
     private readonly CsvExportService? csvExportService;
+    private readonly LatestUiValueDispatcher<LootTrackerSnapshot> snapshotDispatcher;
     private readonly TimeSpan filterDebounceInterval = TimeSpan.FromMilliseconds(250);
     private readonly TimeSpan snapshotRefreshInterval = TimeSpan.FromMilliseconds(100);
     private IDisposable? pendingFilterRefreshRegistration;
-    private IDisposable? pendingSnapshotRefreshRegistration;
-    private LootTrackerSnapshot? pendingSnapshot;
     private IReadOnlyList<LootRecord> allRecords = Array.Empty<LootRecord>();
     private List<LootRecord> filteredRecords = new();
     private string appliedFilterText = string.Empty;
@@ -76,10 +75,16 @@ public partial class LootViewModel : ViewModelBase, IDisposable
 
     public LootViewModel()
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<LootTrackerSnapshot>(
+            ApplySnapshot,
+            snapshotRefreshInterval);
     }
 
     public LootViewModel(LootTrackerService lootTracker, CsvExportService csvExportService)
     {
+        snapshotDispatcher = new LatestUiValueDispatcher<LootTrackerSnapshot>(
+            ApplySnapshot,
+            snapshotRefreshInterval);
         this.lootTracker = lootTracker;
         this.csvExportService = csvExportService;
         lootTracker.SnapshotChanged += OnSnapshotChanged;
@@ -93,8 +98,8 @@ public partial class LootViewModel : ViewModelBase, IDisposable
             lootTracker.SnapshotChanged -= OnSnapshotChanged;
         }
 
+        snapshotDispatcher.Dispose();
         CancelPendingFilterRefresh();
-        CancelPendingSnapshotRefresh();
     }
 
     partial void OnFilterTextChanged(string? oldValue, string newValue)
@@ -159,28 +164,7 @@ public partial class LootViewModel : ViewModelBase, IDisposable
 
     private void OnSnapshotChanged(LootTrackerSnapshot snapshot)
     {
-        if (!Dispatcher.UIThread.CheckAccess())
-        {
-            Dispatcher.UIThread.Post(() => OnSnapshotChanged(snapshot));
-            return;
-        }
-
-        pendingSnapshot = snapshot;
-        if (pendingSnapshotRefreshRegistration is not null)
-        {
-            return;
-        }
-
-        pendingSnapshotRefreshRegistration = DispatcherTimer.RunOnce(() =>
-        {
-            pendingSnapshotRefreshRegistration = null;
-            var snapshotToApply = pendingSnapshot;
-            pendingSnapshot = null;
-            if (snapshotToApply is not null)
-            {
-                ApplySnapshot(snapshotToApply);
-            }
-        }, snapshotRefreshInterval);
+        snapshotDispatcher.Post(snapshot);
     }
 
     private void ApplySnapshot(LootTrackerSnapshot snapshot)
@@ -272,13 +256,6 @@ public partial class LootViewModel : ViewModelBase, IDisposable
     {
         pendingFilterRefreshRegistration?.Dispose();
         pendingFilterRefreshRegistration = null;
-    }
-
-    private void CancelPendingSnapshotRefresh()
-    {
-        pendingSnapshotRefreshRegistration?.Dispose();
-        pendingSnapshotRefreshRegistration = null;
-        pendingSnapshot = null;
     }
 
     private static string NormalizeItemSearchText(string? value)

--- a/PhotonPackageParser/PhotonParser.cs
+++ b/PhotonPackageParser/PhotonParser.cs
@@ -11,10 +11,27 @@ namespace PhotonPackageParser
     {
         private const int CommandHeaderLength = 12;
         private const int PhotonHeaderLength = 12;
+        private const int MaxSegmentedPayloadLength = 16 * 1024 * 1024;
+        private const int MaxPendingSegmentCount = 128;
+        private const int MaxFragmentsPerPayload = 32 * 1024;
+        private const long MaxPendingSegmentBytes = 64L * 1024 * 1024;
+        private static readonly TimeSpan PendingSegmentLifetime = TimeSpan.FromSeconds(30);
 
-        private readonly Dictionary<int, SegmentedPackage> _pendingSegments = new Dictionary<int, SegmentedPackage>();
+        private readonly Dictionary<SegmentedPackageKey, SegmentedPackage> _pendingSegments =
+            new Dictionary<SegmentedPackageKey, SegmentedPackage>();
+        private readonly object _receiveLock = new object();
+        private long _pendingSegmentBytes;
 
         public PacketStatus ReceivePacket(byte[] payload)
+        {
+            lock (_receiveLock)
+            {
+                RemoveExpiredSegments(DateTime.UtcNow);
+                return ReceivePacketCore(payload);
+            }
+        }
+
+        private PacketStatus ReceivePacketCore(byte[] payload)
         {
             if (payload.Length < PhotonHeaderLength)
             {
@@ -59,7 +76,7 @@ namespace PhotonPackageParser
                     return PacketStatus.InvalidHeader;
                 }
 
-                response = HandleCommand(payload, ref offset);
+                response = HandleCommand(payload, ref offset, peerId, challenge);
                 if (response == PacketStatus.InvalidHeader)
                 {
                     return response;
@@ -88,7 +105,11 @@ namespace PhotonPackageParser
         {
         }
 
-        private PacketStatus HandleCommand(byte[] source, ref int offset)
+        private PacketStatus HandleCommand(
+            byte[] source,
+            ref int offset,
+            short peerId,
+            int challenge)
         {
             if (!HasAvailable(source, offset, CommandHeaderLength))
             {
@@ -135,7 +156,13 @@ namespace PhotonPackageParser
                     }
                 case CommandType.SendFragment:
                     {
-                        response = HandleSendFragment(source, ref offset, ref commandLength);
+                        response = HandleSendFragment(
+                            source,
+                            ref offset,
+                            ref commandLength,
+                            peerId,
+                            challenge,
+                            channelId);
                         break;
                     }
                 default:
@@ -220,7 +247,13 @@ namespace PhotonPackageParser
             return PacketStatus.Success;
         }
 
-        private PacketStatus HandleSendFragment(byte[] source, ref int offset, ref int commandLength)
+        private PacketStatus HandleSendFragment(
+            byte[] source,
+            ref int offset,
+            ref int commandLength,
+            short peerId,
+            int challenge,
+            byte channelId)
         {
             const int fragmentHeaderLength = 20;
             if (commandLength < fragmentHeaderLength || !HasAvailable(source, offset, fragmentHeaderLength))
@@ -245,7 +278,34 @@ namespace PhotonPackageParser
                 return PacketStatus.InvalidHeader;
             }
 
-            return HandleSegmentedPayload(startSequenceNumber, totalLength, fragmentLength, fragmentOffset, source, ref offset);
+            if (fragmentCount <= 0 ||
+                fragmentCount > MaxFragmentsPerPayload ||
+                fragmentNumber < 0 ||
+                fragmentNumber >= fragmentCount ||
+                totalLength <= 0 ||
+                totalLength > MaxSegmentedPayloadLength ||
+                fragmentCount > totalLength ||
+                fragmentLength <= 0 ||
+                fragmentOffset < 0 ||
+                fragmentLength > totalLength ||
+                fragmentOffset > totalLength - fragmentLength)
+            {
+                return PacketStatus.InvalidHeader;
+            }
+
+            return HandleSegmentedPayload(
+                new SegmentedPackageKey(
+                    peerId,
+                    challenge,
+                    channelId,
+                    startSequenceNumber),
+                fragmentCount,
+                fragmentNumber,
+                totalLength,
+                fragmentLength,
+                fragmentOffset,
+                source,
+                ref offset);
         }
 
         private PacketStatus HandleFinishedSegmentedPackage(byte[] totalPayload)
@@ -255,38 +315,195 @@ namespace PhotonPackageParser
             return HandleSendReliable(totalPayload, ref offset, ref commandLength);
         }
 
-        private PacketStatus HandleSegmentedPayload(int startSequenceNumber, int totalLength, int fragmentLength, int fragmentOffset, byte[] source, ref int offset)
+        private PacketStatus HandleSegmentedPayload(
+            SegmentedPackageKey segmentKey,
+            int fragmentCount,
+            int fragmentNumber,
+            int totalLength,
+            int fragmentLength,
+            int fragmentOffset,
+            byte[] source,
+            ref int offset)
         {
-            SegmentedPackage segmentedPackage = GetSegmentedPackage(startSequenceNumber, totalLength);
+            DateTime now = DateTime.UtcNow;
+            SegmentedPackage? segmentedPackage = GetSegmentedPackage(
+                segmentKey,
+                totalLength,
+                fragmentCount,
+                now);
+
+            if (segmentedPackage == null)
+            {
+                return PacketStatus.InvalidHeader;
+            }
+
+            if (segmentedPackage.ReceivedFragments.TryGetValue(fragmentNumber, out FragmentRange receivedFragment))
+            {
+                bool matchesExistingFragment =
+                    receivedFragment.Offset == fragmentOffset &&
+                    receivedFragment.Length == fragmentLength &&
+                    PayloadMatches(
+                        source,
+                        offset,
+                        segmentedPackage.TotalPayload,
+                        fragmentOffset,
+                        fragmentLength);
+
+                offset += fragmentLength;
+                if (!matchesExistingFragment)
+                {
+                    return PacketStatus.InvalidHeader;
+                }
+
+                segmentedPackage.LastUpdatedUtc = now;
+                return PacketStatus.Success;
+            }
+
+            foreach (FragmentRange existingFragment in segmentedPackage.ReceivedFragments.Values)
+            {
+                if (RangesOverlap(
+                    fragmentOffset,
+                    fragmentLength,
+                    existingFragment.Offset,
+                    existingFragment.Length))
+                {
+                    return PacketStatus.InvalidHeader;
+                }
+            }
 
             Buffer.BlockCopy(source, offset, segmentedPackage.TotalPayload, fragmentOffset, fragmentLength);
             offset += fragmentLength;
+            segmentedPackage.ReceivedFragments.Add(
+                fragmentNumber,
+                new FragmentRange(fragmentOffset, fragmentLength));
             segmentedPackage.BytesWritten += fragmentLength;
+            segmentedPackage.LastUpdatedUtc = now;
 
-            if (segmentedPackage.BytesWritten >= segmentedPackage.TotalLength)
+            if (segmentedPackage.ReceivedFragments.Count == segmentedPackage.FragmentCount)
             {
-                _pendingSegments.Remove(startSequenceNumber);
-                return HandleFinishedSegmentedPackage(segmentedPackage.TotalPayload);
+                if (segmentedPackage.BytesWritten != segmentedPackage.TotalLength)
+                {
+                    RemovePendingSegment(segmentKey);
+                    return PacketStatus.InvalidHeader;
+                }
+
+                byte[] totalPayload = segmentedPackage.TotalPayload;
+                RemovePendingSegment(segmentKey);
+                return HandleFinishedSegmentedPackage(totalPayload);
+            }
+
+            if (segmentedPackage.BytesWritten == segmentedPackage.TotalLength)
+            {
+                RemovePendingSegment(segmentKey);
+                return PacketStatus.InvalidHeader;
             }
 
             return PacketStatus.Success;
         }
 
-        private SegmentedPackage GetSegmentedPackage(int startSequenceNumber, int totalLength)
+        private SegmentedPackage? GetSegmentedPackage(
+            SegmentedPackageKey segmentKey,
+            int totalLength,
+            int fragmentCount,
+            DateTime now)
         {
-            if (_pendingSegments.TryGetValue(startSequenceNumber, out SegmentedPackage segmentedPackage))
+            if (_pendingSegments.TryGetValue(segmentKey, out SegmentedPackage segmentedPackage))
             {
+                if (segmentedPackage.TotalLength != totalLength ||
+                    segmentedPackage.FragmentCount != fragmentCount)
+                {
+                    return null;
+                }
+
                 return segmentedPackage;
+            }
+
+            if (_pendingSegments.Count >= MaxPendingSegmentCount ||
+                _pendingSegmentBytes > MaxPendingSegmentBytes - totalLength)
+            {
+                return null;
             }
 
             segmentedPackage = new SegmentedPackage
             {
                 TotalLength = totalLength,
+                FragmentCount = fragmentCount,
                 TotalPayload = new byte[totalLength],
+                LastUpdatedUtc = now,
             };
-            _pendingSegments.Add(startSequenceNumber, segmentedPackage);
+            _pendingSegments.Add(segmentKey, segmentedPackage);
+            _pendingSegmentBytes += totalLength;
 
             return segmentedPackage;
+        }
+
+        private void RemoveExpiredSegments(DateTime now)
+        {
+            List<SegmentedPackageKey>? expiredSegmentKeys = null;
+
+            foreach (KeyValuePair<SegmentedPackageKey, SegmentedPackage> entry in _pendingSegments)
+            {
+                if (now - entry.Value.LastUpdatedUtc <= PendingSegmentLifetime)
+                {
+                    continue;
+                }
+
+                if (expiredSegmentKeys == null)
+                {
+                    expiredSegmentKeys = new List<SegmentedPackageKey>();
+                }
+
+                expiredSegmentKeys.Add(entry.Key);
+            }
+
+            if (expiredSegmentKeys == null)
+            {
+                return;
+            }
+
+            foreach (SegmentedPackageKey segmentKey in expiredSegmentKeys)
+            {
+                RemovePendingSegment(segmentKey);
+            }
+        }
+
+        private void RemovePendingSegment(SegmentedPackageKey segmentKey)
+        {
+            if (!_pendingSegments.TryGetValue(segmentKey, out SegmentedPackage segmentedPackage))
+            {
+                return;
+            }
+
+            _pendingSegments.Remove(segmentKey);
+            _pendingSegmentBytes -= segmentedPackage.TotalLength;
+        }
+
+        private static bool RangesOverlap(
+            int firstOffset,
+            int firstLength,
+            int secondOffset,
+            int secondLength)
+        {
+            return firstOffset < secondOffset + secondLength &&
+                   secondOffset < firstOffset + firstLength;
+        }
+
+        private static bool PayloadMatches(
+            byte[] source,
+            int sourceOffset,
+            byte[] destination,
+            int destinationOffset,
+            int count)
+        {
+            for (int index = 0; index < count; index++)
+            {
+                if (source[sourceOffset + index] != destination[destinationOffset + index])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static void ReadByte(out byte value, byte[] source, ref int offset)

--- a/PhotonPackageParser/SegmentedPackage.cs
+++ b/PhotonPackageParser/SegmentedPackage.cs
@@ -1,9 +1,73 @@
-﻿namespace PhotonPackageParser
+﻿using System;
+using System.Collections.Generic;
+
+namespace PhotonPackageParser
 {
-    internal class SegmentedPackage
+    internal readonly struct SegmentedPackageKey : IEquatable<SegmentedPackageKey>
+    {
+        public SegmentedPackageKey(
+            short peerId,
+            int challenge,
+            byte channelId,
+            int startSequenceNumber)
+        {
+            PeerId = peerId;
+            Challenge = challenge;
+            ChannelId = channelId;
+            StartSequenceNumber = startSequenceNumber;
+        }
+
+        public short PeerId { get; }
+        public int Challenge { get; }
+        public byte ChannelId { get; }
+        public int StartSequenceNumber { get; }
+
+        public bool Equals(SegmentedPackageKey other)
+        {
+            return PeerId == other.PeerId
+                && Challenge == other.Challenge
+                && ChannelId == other.ChannelId
+                && StartSequenceNumber == other.StartSequenceNumber;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is SegmentedPackageKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = PeerId.GetHashCode();
+                hashCode = (hashCode * 397) ^ Challenge;
+                hashCode = (hashCode * 397) ^ ChannelId.GetHashCode();
+                hashCode = (hashCode * 397) ^ StartSequenceNumber;
+                return hashCode;
+            }
+        }
+    }
+
+    internal sealed class SegmentedPackage
     {
         public int TotalLength;
+        public int FragmentCount;
         public int BytesWritten;
-        public byte[] TotalPayload;
+        public byte[] TotalPayload = Array.Empty<byte>();
+        public DateTime LastUpdatedUtc;
+        public Dictionary<int, FragmentRange> ReceivedFragments = new Dictionary<int, FragmentRange>();
+    }
+
+    internal readonly struct FragmentRange
+    {
+        public FragmentRange(int offset, int length)
+        {
+            Offset = offset;
+            Length = length;
+        }
+
+        public int Offset { get; }
+
+        public int Length { get; }
     }
 }


### PR DESCRIPTION
## Summary

- Bound Photon fragment reassembly with connection-aware keys, validation, size/count limits, and stale-fragment expiry.
- Make packet-capture startup, restart, suspend/resume, and cleanup lifecycle cancellation-aware so overlapping sessions cannot retain orphaned capture devices or callbacks.
- Coalesce Combat, Gathering, Loot, and Logs updates before dispatching them to the UI, preventing an unbounded dispatcher backlog during sustained traffic.

## Motivation

A Windows user reported roughly 20 GB of memory use after leaving two clients running across sleep/hibernate cycles. The likely growth paths were incomplete Photon fragments retained indefinitely, overlapping capture sessions after lifecycle events, and UI snapshots/log callbacks queued faster than the UI could process them.

## Validation

- `git diff --check`
- Parsed all changed C# files for syntax errors
- Two independent static/concurrency reviews of the lifecycle and buffering changes
- Confirmed the remote diff is one commit ahead of `beta`, with the intended eight files only

`dotnet build` was not run because the .NET SDK is not installed in this workspace. The repository currently has no automated test suite to run.